### PR TITLE
Fix for `-dce full` with recent Haxe nighlities

### DIFF
--- a/src/ANSI.hx
+++ b/src/ANSI.hx
@@ -101,18 +101,10 @@ class ANSI {
 		
 	];
 	
-	public static var set:Dynamic;
-	public static var available:Bool;
+	public static var set:Dynamic = Reflect.makeVarArgs(aset);
+	public static var available = detectSupport();
 	public static var strip:Bool = false;
 	public static var stripIfUnavailable:Bool = true;
-	
-	private static var initExec = init();
-
-	public static function init() {
-		set = Reflect.makeVarArgs(aset);
-		available = detectSupport();
-		return true;
-	}
 	
 	@:ansi
 	public static function aset(attributes:Array<Dynamic>):String {


### PR DESCRIPTION
At least with HaxeFoundation/haxe@9617d71 I was having issues with running the
tests: `-dce full` was causing the initialization code to be removed.

I chose to not depend on a explicit `@:keep`, so that the class can be removed
if it's not being used at all.